### PR TITLE
Fix gradle application run task

### DIFF
--- a/Table2Geojson/build.gradle.kts
+++ b/Table2Geojson/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
 }
 
 application {
-    mainClass.set("de.l.oklab.pumps.Table2GeojsonMain")
+    mainClass.set("de.l.oklab.pumps.Table2GeojsonMainKt")
 }
 
 


### PR DESCRIPTION
use the generated Java class name to avoid
java.lang.ClassNotFoundException: de.l.oklab.pumps.Table2GeojsonMain